### PR TITLE
Direct lookup of gradients' moments

### DIFF
--- a/examples/xor_classification.cpp
+++ b/examples/xor_classification.cpp
@@ -25,7 +25,7 @@ int main() {
                 .build();
     // clang-format on
 
-    SGD32 optimizer = SGD<Type::float32>(mlp->parameters(), 0.1);
+    Adam32 optimizer = Adam<Type::float32>(mlp->parameters(), 0.1);
     Loss::Function32 lossFunction = Loss::CrossEntropy<Type::float32>;
 
     // ------ TRAINING THE NETWORK ------- //

--- a/include/nn/optimizers/Adam.hpp
+++ b/include/nn/optimizers/Adam.hpp
@@ -28,11 +28,8 @@ template <typename T> class Adam : public Optimizer<T> {
     T _eps;
     size_t _timestep;
 
-    std::unordered_map<Value<T> *, T> _firstMoment;
-    std::unordered_map<Value<T> *, T> _secondMoment;
-
-    T getFirstMoment(const ValuePtr<T> &v);
-    T getSecondMoment(const ValuePtr<T> &v);
+    std::vector<T> _firstMoments;
+    std::vector<T> _secondMoments;
 
   public:
     Adam(std::vector<ValuePtr<T>> params, T learningRate, T b1 = 0.9, T b2 = 0.999, T eps = 1e-8);
@@ -42,47 +39,34 @@ template <typename T> class Adam : public Optimizer<T> {
 
 template <typename T>
 Adam<T>::Adam(std::vector<ValuePtr<T>> params, T learningRate, T b1, T b2, T eps) : Optimizer<T>(params, learningRate) {
-    _timestep = 0;
     _b1 = b1;
     _b2 = b2;
     _eps = eps;
+
+    _timestep = 0;
+    _firstMoments.resize(params.size(), 0);
+    _secondMoments.resize(params.size(), 0);
 }
 
 template <typename T> void Adam<T>::step() {
     _timestep++;
 
-    for (const ValuePtr<T> &param : this->_parameters) {
+    for (size_t i = 0; i < this->_parameters.size(); ++i) {
+        const ValuePtr<T> &param = this->_parameters[i];
+
         T gradient = param->getGradient();
 
-        T firstMoment = _b1 * getFirstMoment(param) + (1 - _b1) * gradient;
-        T secondMoment = _b2 * getSecondMoment(param) + (1 - _b2) * gradient * gradient;
+        T firstMoment = _b1 * _firstMoments[i] + (1 - _b1) * gradient;
+        T secondMoment = _b2 * _secondMoments[i] + (1 - _b2) * gradient * gradient;
 
-        _firstMoment.insert({param.get(), firstMoment});
-        _secondMoment.insert({param.get(), secondMoment});
+        _firstMoments[i] = firstMoment;
+        _secondMoments[i] = secondMoment;
 
         T firstMomentHat = firstMoment / (1 - pow(_b1, _timestep));
         T secondMomentHat = secondMoment / (1 - pow(_b2, _timestep));
 
         param->_data -= (this->_learningRate * firstMomentHat) / (sqrt(secondMomentHat) + _eps);
     }
-}
-
-template <typename T> T Adam<T>::getFirstMoment(const ValuePtr<T> &v) {
-    auto moment = _firstMoment.find(v.get());
-    if (moment == _firstMoment.end()) {
-        _firstMoment.insert({v.get(), 0});
-        return 0;
-    }
-    return moment->second;
-}
-
-template <typename T> T Adam<T>::getSecondMoment(const ValuePtr<T> &v) {
-    auto moment = _secondMoment.find(v.get());
-    if (moment == _secondMoment.end()) {
-        _secondMoment.insert({v.get(), 0});
-        return 0;
-    }
-    return moment->second;
 }
 
 } // namespace shkyera


### PR DESCRIPTION
Adam and SGD use a constant-size vector for lookup of gradients' moments instead of a hash-map.